### PR TITLE
Use rsync to sync folder with libvirt provider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant.configure("2") do |config|
         lv.keymap = 'pt'
         # replace the default synced_folder with something that works in the base box.
         # NB for some reason, this does not work when placed in the base box Vagrantfile.
-        config.vm.synced_folder '.', '/vagrant', type: 'smb', smb_username: ENV['USER'], smb_password: ENV['VAGRANT_SMB_PASSWORD']
+        config.vm.synced_folder '.', '/vagrant', type: 'rsync'
     end
 
     config.vm.provider :virtualbox do |v, override|

--- a/test-nodes/Vagrantfile
+++ b/test-nodes/Vagrantfile
@@ -21,7 +21,7 @@ Vagrant.configure("2") do |config|
             lv.memory = 2048
             # replace the default synced_folder with something that works in the base box.
             # NB for some reason, this does not work when placed in the base box Vagrantfile.
-            config.vm.synced_folder '.', '/vagrant', type: 'smb', smb_username: ENV['USER'], smb_password: ENV['VAGRANT_SMB_PASSWORD']
+            config.vm.synced_folder '.', '/vagrant', type: 'rsync'
         end
         config.vm.provider :virtualbox do |v, override|
             v.memory = 2048


### PR DESCRIPTION
`smb` sync folder method only works on windows and MacOS host machines, [according to this](https://www.vagrantup.com/docs/synced-folders/smb), causing the build to fail. Using rsync works without issues.